### PR TITLE
Display user's and user's follower(s)' mood events on map

### DIFF
--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
@@ -1,32 +1,128 @@
 package com.cmput3owo1.moodlet.adapters;
 
+import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
 
+import com.cmput3owo1.moodlet.R;
+import com.cmput3owo1.moodlet.models.EmotionalState;
+import com.cmput3owo1.moodlet.models.MoodEvent;
+import com.cmput3owo1.moodlet.models.MoodEventAssociation;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.Marker;
 
+import java.text.SimpleDateFormat;
+
 public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
 
+    private String pattern = "MMMM d, yyyy - h:mm a";
+    private SimpleDateFormat sdf = new SimpleDateFormat(pattern);
+
+    private LayoutInflater inflater;
+
+    private TextView usernameInfo;
+    private TextView locationInfo;
+    private TextView emotionInfo;
+    private TextView dateInfo;
+    private TextView timeInfo;
+    private ImageView emoticonInfo;
+    private ImageView infoWindowBar;
+
+    public MapMarkerInfoWindowAdapter(LayoutInflater inflater) {
+        this.inflater = inflater;
+    }
+
     /**
-     * This function customizes what is displayed in the map marker's info window
-     * @param marker
-     * @return
+     * This function customizes what is displayed in the map marker's info window.
+     * @param marker The marker for which an info window is being populated.
+     * @return A custom info window for marker, or null to use the default info window frame with
+     * custom contents.
      */
     @Override
     public View getInfoWindow(Marker marker) {
-        // TODO
+        View infoWindow = inflater.inflate(R.layout.marker_info_window, null);
+
+        usernameInfo = infoWindow.findViewById(R.id.usernameInfo);
+        locationInfo = infoWindow.findViewById(R.id.locationInfo);
+        emotionInfo = infoWindow.findViewById(R.id.emotionInfo);
+        dateInfo = infoWindow.findViewById(R.id.dateInfo);
+        timeInfo = infoWindow.findViewById(R.id.timeInfo);
+        emoticonInfo = infoWindow.findViewById(R.id.emoticonInfo);
+        infoWindowBar = infoWindow.findViewById(R.id.infoWindowBar);
+
+        Object tagObject = marker.getTag();
+
+        if (tagObject != null) {
+            Log.e("MOODLET", tagObject.getClass().toString());
+            if (tagObject.getClass().equals(MoodEvent.class)) {
+                Log.e("MOODLET", "My Mood Event");
+                MoodEvent moodEvent = (MoodEvent) tagObject;
+                locationInfo.setText("Location placeholder");
+                emotionInfo.setText(moodEvent.getEmotionalState().getDisplayName());
+                dateInfo.setText(sdf.format(moodEvent.getDate()));
+                timeInfo.setText("? h");
+                setEmoticon(moodEvent.getEmotionalState());
+                infoWindowBar.setColorFilter(moodEvent.getEmotionalState().getColor());
+            } else if (tagObject.getClass().equals(MoodEventAssociation.class)) {
+                Log.e("MOODLET", "Follower Mood Event");
+                MoodEventAssociation moodEventAssociation = (MoodEventAssociation) tagObject;
+                MoodEvent moodEvent = moodEventAssociation.getMoodEvent();
+                usernameInfo.setText(String.format("@%s - ", moodEventAssociation.getUsername()));
+                locationInfo.setText("Location placeholder");
+                emotionInfo.setText(moodEvent.getEmotionalState().getDisplayName());
+                dateInfo.setText(sdf.format(moodEvent.getDate()));
+                timeInfo.setText("? h");
+                setEmoticon(moodEvent.getEmotionalState());
+                infoWindowBar.setColorFilter(moodEvent.getEmotionalState().getColor());
+            }
+            return infoWindow;
+        }
+
         return null;
     }
 
     /**
      * This function customizes what is displayed in the map marker's info window but also
-     * keeps the default info window frame and background
-     * @param marker
-     * @return
+     * keeps the default info window frame and background. The implementation for this method is
+     * not needed since {@link MapMarkerInfoWindowAdapter#getInfoWindow(Marker)} will be called.
+     * @param marker The marker for which an info window is being populated.
+     * @return A custom view to display as contents in the info window for marker, or null
+     * to use the default content rendering instead.
      */
     @Override
     public View getInfoContents(Marker marker) {
-        // TODO
         return null;
+    }
+
+    /**
+     * Helper function to set the ImageView to the correct emoticon for the mood
+     * @param emotionalState The emotional state to set the emoticon to.
+     */
+    private void setEmoticon(EmotionalState emotionalState) {
+        switch(emotionalState) {
+            case SAD:
+                emoticonInfo.setImageResource(R.drawable.ic_mood_sad);
+                break;
+            case ANGRY:
+                emoticonInfo.setImageResource(R.drawable.ic_mood_angry);
+                break;
+            case CONFUSED:
+                emoticonInfo.setImageResource(R.drawable.ic_mood_confused);
+                break;
+            case EXCITED:
+                emoticonInfo.setImageResource(R.drawable.ic_mood_excited);
+                break;
+            case HAPPY:
+                emoticonInfo.setImageResource(R.drawable.ic_mood_happy);
+                break;
+            case JEALOUS:
+                emoticonInfo.setImageResource(R.drawable.ic_mood_jealous);
+                break;
+            case SCARED:
+                emoticonInfo.setImageResource(R.drawable.ic_mood_scared);
+                break;
+        }
     }
 }

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
@@ -4,6 +4,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.cmput3owo1.moodlet.R;
@@ -22,6 +23,7 @@ public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
 
     private LayoutInflater inflater;
 
+    private LinearLayout infoWindowTitle;
     private TextView usernameInfo;
     private TextView locationInfo;
     private TextView emotionInfo;
@@ -44,6 +46,7 @@ public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
     public View getInfoWindow(Marker marker) {
         View infoWindow = inflater.inflate(R.layout.marker_info_window, null);
 
+        infoWindowTitle = infoWindow.findViewById(R.id.infoWindowTitle);
         usernameInfo = infoWindow.findViewById(R.id.usernameInfo);
         locationInfo = infoWindow.findViewById(R.id.locationInfo);
         emotionInfo = infoWindow.findViewById(R.id.emotionInfo);
@@ -59,23 +62,14 @@ public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
             if (tagObject.getClass().equals(MoodEvent.class)) {
                 Log.e("MOODLET", "My Mood Event");
                 MoodEvent moodEvent = (MoodEvent) tagObject;
-                locationInfo.setText("Location placeholder");
-                emotionInfo.setText(moodEvent.getEmotionalState().getDisplayName());
-                dateInfo.setText(sdf.format(moodEvent.getDate()));
-                timeInfo.setText("? h");
-                setEmoticon(moodEvent.getEmotionalState());
-                infoWindowBar.setColorFilter(moodEvent.getEmotionalState().getColor());
+                setInfo(moodEvent, false);
+
             } else if (tagObject.getClass().equals(MoodEventAssociation.class)) {
                 Log.e("MOODLET", "Follower Mood Event");
                 MoodEventAssociation moodEventAssociation = (MoodEventAssociation) tagObject;
                 MoodEvent moodEvent = moodEventAssociation.getMoodEvent();
                 usernameInfo.setText(String.format("@%s - ", moodEventAssociation.getUsername()));
-                locationInfo.setText("Location placeholder");
-                emotionInfo.setText(moodEvent.getEmotionalState().getDisplayName());
-                dateInfo.setText(sdf.format(moodEvent.getDate()));
-                timeInfo.setText("? h");
-                setEmoticon(moodEvent.getEmotionalState());
-                infoWindowBar.setColorFilter(moodEvent.getEmotionalState().getColor());
+                setInfo(moodEvent, true);
             }
             return infoWindow;
         }
@@ -94,6 +88,24 @@ public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
     @Override
     public View getInfoContents(Marker marker) {
         return null;
+    }
+
+    /**
+     * Sets the information on the info window from the given mood event.
+     * @param moodEvent The mood event to obtain the information from.
+     * @param isFollower A flag to indicate whether the mood event information is from a follower
+     */
+    private void setInfo(MoodEvent moodEvent, boolean isFollower) {
+        String locationDescription = moodEvent.getLocationDescription();
+        locationInfo.setText(locationDescription);
+        if (!isFollower && locationDescription == null) {
+            infoWindowTitle.setVisibility(View.GONE);
+        }
+        emotionInfo.setText(moodEvent.getEmotionalState().getDisplayName());
+        dateInfo.setText(sdf.format(moodEvent.getDate()));
+        timeInfo.setText("? h");
+        setEmoticon(moodEvent.getEmotionalState());
+        infoWindowBar.setColorFilter(moodEvent.getEmotionalState().getColor());
     }
 
     /**

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
@@ -33,6 +33,10 @@ public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
     private ImageView emoticonInfo;
     private ImageView infoWindowBar;
 
+    /**
+     * Constructor for the MapMarkerInfoWindowAdapter
+     * @param inflater The LayoutInflater object that can be used to inflate any views in the parent fragment.
+     */
     public MapMarkerInfoWindowAdapter(LayoutInflater inflater) {
         this.inflater = inflater;
     }

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
@@ -1,6 +1,5 @@
 package com.cmput3owo1.moodlet.adapters;
 
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;
@@ -15,6 +14,8 @@ import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.Marker;
 
 import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 
 public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
 
@@ -58,17 +59,18 @@ public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
         Object tagObject = marker.getTag();
 
         if (tagObject != null) {
-            Log.e("MOODLET", tagObject.getClass().toString());
             if (tagObject.getClass().equals(MoodEvent.class)) {
-                Log.e("MOODLET", "My Mood Event");
                 MoodEvent moodEvent = (MoodEvent) tagObject;
                 setInfo(moodEvent, false);
 
             } else if (tagObject.getClass().equals(MoodEventAssociation.class)) {
-                Log.e("MOODLET", "Follower Mood Event");
                 MoodEventAssociation moodEventAssociation = (MoodEventAssociation) tagObject;
                 MoodEvent moodEvent = moodEventAssociation.getMoodEvent();
-                usernameInfo.setText(String.format("@%s - ", moodEventAssociation.getUsername()));
+                if (moodEventAssociation.getMoodEvent().getLocationDescription() == null) {
+                    usernameInfo.setText(String.format("@%s", moodEventAssociation.getUsername()));
+                } else {
+                    usernameInfo.setText(String.format("@%s - ", moodEventAssociation.getUsername()));
+                }
                 setInfo(moodEvent, true);
             }
             return infoWindow;
@@ -102,10 +104,42 @@ public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
             infoWindowTitle.setVisibility(View.GONE);
         }
         emotionInfo.setText(moodEvent.getEmotionalState().getDisplayName());
-        dateInfo.setText(sdf.format(moodEvent.getDate()));
-        timeInfo.setText("? h");
+        Date date = moodEvent.getDate();
+        dateInfo.setText(sdf.format(date));
+        timeInfo.setText(getTimeDifference(date));
         setEmoticon(moodEvent.getEmotionalState());
         infoWindowBar.setColorFilter(moodEvent.getEmotionalState().getColor());
+    }
+
+    /**
+     * Helper function to obtain the time difference between the current date to the specified date
+     * @param date The date to compare with.
+     * @return A formatted string for the time difference
+     */
+    private String getTimeDifference(Date date) {
+        // Get the date difference in milliseconds
+        long dateDiff = (new Date()).getTime() - date.getTime();
+
+        // Separate into different time units
+        long diffSeconds = dateDiff / 1000;
+        long diffMinutes = diffSeconds / 60;
+        long diffHours = diffMinutes / 60;
+        long diffDays = diffHours / 24;
+        long diffYears = diffDays / 365;
+
+        if (diffYears >= 1) {
+            return String.format(Locale.US, "%d y", (int) diffYears);
+        } else if (diffDays >= 1) {
+            return String.format(Locale.US, "%d d", (int) diffDays);
+        } else if (diffHours >= 1) {
+            return String.format(Locale.US, "%d h", (int) diffHours);
+        } else if (diffMinutes >= 1) {
+            return String.format(Locale.US, "%d m", (int) diffMinutes);
+        } else if (diffSeconds >= 1) {
+            return String.format(Locale.US, "%d s", (int) diffSeconds);
+        } else {
+            return "0 s";
+        }
     }
 
     /**

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/adapters/MapMarkerInfoWindowAdapter.java
@@ -1,0 +1,32 @@
+package com.cmput3owo1.moodlet.adapters;
+
+import android.view.View;
+
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.Marker;
+
+public class MapMarkerInfoWindowAdapter implements GoogleMap.InfoWindowAdapter {
+
+    /**
+     * This function customizes what is displayed in the map marker's info window
+     * @param marker
+     * @return
+     */
+    @Override
+    public View getInfoWindow(Marker marker) {
+        // TODO
+        return null;
+    }
+
+    /**
+     * This function customizes what is displayed in the map marker's info window but also
+     * keeps the default info window frame and background
+     * @param marker
+     * @return
+     */
+    @Override
+    public View getInfoContents(Marker marker) {
+        // TODO
+        return null;
+    }
+}

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/AddMoodFragment.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/AddMoodFragment.java
@@ -323,7 +323,6 @@ public class AddMoodFragment extends Fragment implements
                 } else if (placesLocation != null) {
                     mood.setLocation(placesLocation);
                     mood.setLocationDescription(placesLocationDescription);
-                    // TODO: Set the place's description?
                 }
 
                 String[] words = reasonEdit.getText().toString().split(" ");

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/AddMoodFragment.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/AddMoodFragment.java
@@ -104,6 +104,7 @@ public class AddMoodFragment extends Fragment implements
     private LocationCallback locationCallback;
     private Location currentLocation;
     private GeoPoint placesLocation;
+    private String placesLocationDescription;
     private static final String[] PERMISSIONS = { Manifest.permission.ACCESS_FINE_LOCATION };
     private static final int LOCATION_REQUEST_CODE = 1;
     public static final int REQUEST_CHECK_SETTINGS = 2; // Keep public to access in parent activity
@@ -210,6 +211,7 @@ public class AddMoodFragment extends Fragment implements
             @Override
             public void onClick(View v) {
                 placesLocation = null;
+                placesLocationDescription = null;
                 locationEdit.setText("");
             }
         });
@@ -320,6 +322,7 @@ public class AddMoodFragment extends Fragment implements
                     mood.setLocation(new GeoPoint(currentLocation.getLatitude(), currentLocation.getLongitude()));
                 } else if (placesLocation != null) {
                     mood.setLocation(placesLocation);
+                    mood.setLocationDescription(placesLocationDescription);
                     // TODO: Set the place's description?
                 }
 
@@ -401,6 +404,7 @@ public class AddMoodFragment extends Fragment implements
                 Place place = Autocomplete.getPlaceFromIntent(data);
                 LatLng latLng = place.getLatLng();
                 placesLocation = new GeoPoint(latLng.latitude, latLng.longitude);
+                placesLocationDescription = place.getName();
                 locationEdit.setText(String.format("%s, %s", place.getName(), place.getAddress()));
             }
         } else {

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/MapFragment.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/MapFragment.java
@@ -185,6 +185,14 @@ public class MapFragment extends Fragment implements
         // Set the update callbacks
         moodEventService.getMoodHistoryUpdates(this);
         moodEventService.getFeedUpdates(this);
+
+        // Set a click listener for the checkbox
+        showFollowersCheckbox.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                updateMap(showFollowersCheckbox.isChecked());
+            }
+        });
     }
 
     /**
@@ -233,9 +241,17 @@ public class MapFragment extends Fragment implements
 
         // Add markers for follower(s)' mood events
         if (showFollowers) {
-            // TODO: clear
             for (MoodEventAssociation moodEventAssociation : followerMoodEvents) {
-                // TODO
+                GeoPoint location = moodEventAssociation.getMoodEvent().getLocation();
+                if (location != null) {
+                    LatLng latLng = new LatLng(location.getLatitude(), location.getLongitude());
+                    Marker marker = map.addMarker(new MarkerOptions()
+                            .position(latLng)
+                            .icon(BitmapDescriptorFactory.defaultMarker(FOLLOWER_MARKER_COLOR))
+                            .alpha(0.8f)
+                    );
+                    marker.setTag(moodEventAssociation);
+                }
             }
         }
     }

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/MapFragment.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/MapFragment.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.cmput3owo1.moodlet.R;
+import com.cmput3owo1.moodlet.adapters.MapMarkerInfoWindowAdapter;
 import com.cmput3owo1.moodlet.models.MoodEvent;
 import com.cmput3owo1.moodlet.models.MoodEventAssociation;
 import com.cmput3owo1.moodlet.services.IMoodEventServiceProvider;
@@ -20,10 +21,10 @@ import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapView;
 import com.google.android.gms.maps.OnMapReadyCallback;
-import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.MapStyleOptions;
+import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.firebase.firestore.GeoPoint;
 
@@ -41,8 +42,9 @@ public class MapFragment extends Fragment implements
     private static final String TAG = "Moodlet";
     private static final LatLng EDMONTON = new LatLng(53.5444,-113.4909);
     private static final float MARKER_COLOR = 207.61f; // Hue
-//    private static final float FOLLOWER_MARKER_COLOR =
+    private static final float FOLLOWER_MARKER_COLOR = 164f;
 
+    private LayoutInflater inflater;
 
     private IMoodEventServiceProvider moodEventService;
 
@@ -64,8 +66,12 @@ public class MapFragment extends Fragment implements
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
+
+        // Set the layout inflater
+        this.inflater = inflater;
+
         // Obtain the view to inflate
-        View view = inflater.inflate(R.layout.fragment_map, container, false);
+        View view = this.inflater.inflate(R.layout.fragment_map, container, false);
 
         // Get checkbox
         showFollowersCheckbox = view.findViewById(R.id.showFollowers);
@@ -155,7 +161,8 @@ public class MapFragment extends Fragment implements
     @Override
     public void onMapReady(GoogleMap map) {
         this.map = map;
-
+        this.map.getUiSettings().setMapToolbarEnabled(false);
+        this.map.setInfoWindowAdapter(new MapMarkerInfoWindowAdapter(this.inflater));
         // TODO: Set camera to last known/recorded location
         // this.map.setMyLocationEnabled(true);
         // this.map.setOnMyLocationButtonClickListener(mapView.getContext());
@@ -215,12 +222,12 @@ public class MapFragment extends Fragment implements
             GeoPoint location = moodEvent.getLocation();
             if (location != null) {
                 LatLng latLng = new LatLng(location.getLatitude(), location.getLongitude());
-                map.addMarker(new MarkerOptions()
+                Marker marker = map.addMarker(new MarkerOptions()
                         .position(latLng)
                         .icon(BitmapDescriptorFactory.defaultMarker(MARKER_COLOR))
                         .alpha(0.8f)
-                        .title(moodEvent.getEmotionalState().getDisplayName())
                 );
+                marker.setTag(moodEvent);
             }
         }
 

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/MapFragment.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/fragments/MapFragment.java
@@ -180,13 +180,12 @@ public class MapFragment extends Fragment implements
 
         // TODO: change this to the last known location
         this.map.moveCamera(CameraUpdateFactory.newLatLngZoom(EDMONTON, 12));
-//        updateMap(showFollowersCheckbox.isChecked());
 
         // Set the update callbacks
         moodEventService.getMoodHistoryUpdates(this);
         moodEventService.getFeedUpdates(this);
 
-        // Set a click listener for the checkbox
+        // Set a click listener for the checkbox to show followers' mood events
         showFollowersCheckbox.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -254,15 +253,5 @@ public class MapFragment extends Fragment implements
                 }
             }
         }
-    }
-
-    /**
-     * Creates
-     * @param moodEvent
-     * @param position
-     * @return
-     */
-    private MarkerOptions createMarkerOptions(MoodEvent moodEvent, LatLng position) {
-        return null;
     }
 }

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/models/MoodEvent.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/models/MoodEvent.java
@@ -14,6 +14,7 @@ public class MoodEvent extends Event implements Serializable {
     private String reasoning;
     private SocialSituation socialSituation;
     private String photographPath;
+    private String locationDescription;
 
     /**
      * Default constructor for the MoodEvent.
@@ -110,5 +111,21 @@ public class MoodEvent extends Event implements Serializable {
      */
     public void setPhotographPath(String photographPath) {
         this.photographPath = photographPath;
+    }
+
+    /**
+     * This gets the location description (place) associated with the MoodEvent.
+     * @return The location's description
+     */
+    public String getLocationDescription() {
+        return this.locationDescription;
+    }
+
+    /**
+     * This sets the location description (place) associated with the MoodEvent.
+     * @param locationDescription The location's description.
+     */
+    public void setLocationDescription(String locationDescription) {
+        this.locationDescription = locationDescription;
     }
 }

--- a/Moodlet/app/src/main/res/drawable/ic_infowindowbar.xml
+++ b/Moodlet/app/src/main/res/drawable/ic_infowindowbar.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="612dp"
+    android:height="77dp"
+    android:viewportWidth="612"
+    android:viewportHeight="77">
+  <path
+      android:pathData="M612,0l0,41l-281,0l-25,36l-25,-36l-281,0l0,-41z"
+      android:fillColor="#4F91CD"/>
+</vector>

--- a/Moodlet/app/src/main/res/layout/fragment_add_mood.xml
+++ b/Moodlet/app/src/main/res/layout/fragment_add_mood.xml
@@ -148,10 +148,12 @@
 
             <EditText
                 android:id="@+id/reasonEdit"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
                 android:layout_marginTop="8dp"
                 android:maxLength="20"
                 android:hint="@string/reason"

--- a/Moodlet/app/src/main/res/layout/fragment_map.xml
+++ b/Moodlet/app/src/main/res/layout/fragment_map.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -10,4 +9,34 @@
         android:layout_height="match_parent"
         android:id="@+id/mapView" />
 
-</LinearLayout>
+    <androidx.cardview.widget.CardView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="15dp"
+        android:layout_margin="10dp"
+        android:layout_gravity="bottom|end" >
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="5dp" >
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="14sp"
+                android:text="@string/show_friends"
+                android:paddingStart="15dp"
+                android:paddingEnd="15dp" />
+
+            <CheckBox
+                android:id="@+id/showFollowers"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+    </androidx.cardview.widget.CardView>
+
+
+</FrameLayout>

--- a/Moodlet/app/src/main/res/layout/marker_info_window.xml
+++ b/Moodlet/app/src/main/res/layout/marker_info_window.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="10dp">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="10dp">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:padding="5dp">
+
+                <TextView
+                    android:id="@+id/usernameInfo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/locationInfo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:padding="5dp">
+
+                <ImageView
+                    android:id="@+id/emoticonInfo"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_weight="1"
+                    android:padding="5dp"
+                    android:layout_gravity="center_horizontal" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:layout_weight="3"
+                    android:padding="5dp">
+
+                    <TextView
+                        android:id="@+id/emotionInfo"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textStyle="bold"
+                        android:textSize="18sp" />
+
+                    <TextView
+                        android:id="@+id/dateInfo"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="14sp" />
+
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/timeInfo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textStyle="bold"
+                    android:textSize="14sp"
+                    android:padding="5dp"
+                    android:layout_marginStart="15dp"
+                    android:layout_marginLeft="15dp"
+                    android:layout_gravity="center" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </androidx.cardview.widget.CardView>
+
+    <ImageView
+        android:id="@+id/infoWindowBar"
+        android:layout_width="match_parent"
+        android:layout_height="20dp"
+        android:src="@drawable/ic_infowindowbar"
+        android:scaleType="fitXY" />
+
+</LinearLayout>

--- a/Moodlet/app/src/main/res/layout/marker_info_window.xml
+++ b/Moodlet/app/src/main/res/layout/marker_info_window.xml
@@ -16,6 +16,7 @@
             android:padding="10dp">
 
             <LinearLayout
+                android:id="@+id/infoWindowTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"

--- a/Moodlet/app/src/main/res/values/strings.xml
+++ b/Moodlet/app/src/main/res/values/strings.xml
@@ -35,4 +35,5 @@
     <string name="location_clear">(Clear)</string>
     <string name="location_permissions_denied">Location permissions are needed to tag the current location</string>
     <string name="location_settings_denied">Location settings are needed to tag the current location</string>
+    <string name="show_friends">Show Friends</string>
 </resources>


### PR DESCRIPTION
<!-- Each PR should close an issue -->
<!-- An example of closing multiple issues: Closes #1, closes #2, etc... -->
Closes #38 ,
Closes #39 

<!-- Add a brief description of what your code does -->
**Summary**

Enables the user to view their mood events associated with a location on a map, as well as view the latest mood events from their followers if they are associated with a location.

**Notes:**
- Added a new field to the MoodEvent model class: `locationDescription`. This does not affect the current data in the database - no nuking required

<!-- Add this PR to the Product Backlog project -->