### PR TITLE
Fix: Edit/delete sends the proper update to followers

### DIFF
--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/services/MoodEventService.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/services/MoodEventService.java
@@ -93,7 +93,6 @@ public class MoodEventService implements IMoodEventServiceProvider {
         return newMoodEventRef.getId();
     }
 
-
     /**
      * Edit an existing MoodEvent on the database.
      * @param moodEvent The {@link MoodEvent} to edit.
@@ -238,7 +237,12 @@ public class MoodEventService implements IMoodEventServiceProvider {
 
         runMoodHistoryQuery(moodHistoryQuery, listener);
     }
-    
+
+    /**
+     * Run the specified Mood History query and notify the listener on completion
+     * @param moodHistoryQuery The query to run
+     * @param listener The listener to pass the new mood history list to
+     */
     private void runMoodHistoryQuery(Query moodHistoryQuery, final OnMoodHistoryUpdateListener listener) {
         moodHistoryQuery.addSnapshotListener(new EventListener<QuerySnapshot>() {
             @Override
@@ -252,6 +256,7 @@ public class MoodEventService implements IMoodEventServiceProvider {
             }
         });
     }
+
     /**
      * Listen to mood history updates of the current user. Calls the listener's onMoodHistoryUpdate
      * method with the new mood history list when a change occurs.

--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/services/MoodEventService.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/services/MoodEventService.java
@@ -127,6 +127,10 @@ public class MoodEventService implements IMoodEventServiceProvider {
         listener.onMoodUpdateSuccess();
     }
 
+    /**
+     * Update the feed or friend activity of the current user's followers with the specified MoodEvent
+     * @param moodEvent The most recent {@link MoodEvent} of the current user
+     */
     private void updateFollowersFeed(final MoodEvent moodEvent) {
         final String username = auth.getCurrentUser().getDisplayName();
 


### PR DESCRIPTION
<!-- Each PR should close an issue -->
<!-- An example of closing multiple issues: Closes #1, closes #2, etc... -->
Closes #104 

<!-- Add a brief description of what your code does -->
**Summary**
Before, editing or deleting the most recent mood event didn't send updates to followers. Now it puts it into their feed.

<!-- Add this PR to the Product Backlog project -->