### PR TITLE
Fixed following/requested fields going to Firestore

### DIFF
--- a/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/models/User.java
+++ b/Moodlet/app/src/main/java/com/cmput3owo1/moodlet/models/User.java
@@ -1,5 +1,7 @@
 package com.cmput3owo1.moodlet.models;
 
+import com.google.firebase.firestore.Exclude;
+
 /**
  * Class to represent an app user. Contains just the basic info about the user: username, fullName,
  * and email.
@@ -80,6 +82,7 @@ public class User {
         this.email = email;
     }
 
+    @Exclude
     public boolean isRequested() {
         return requested;
     }
@@ -88,6 +91,7 @@ public class User {
         this.requested = requested;
     }
 
+    @Exclude
     public boolean isFollowing() {
         return following;
     }


### PR DESCRIPTION

<!-- Add a brief description of what your code does -->
**Summary**
The following/requested fields on the User object are just for operations performed within the app. They should not be updated in Firestore

<!-- Add this PR to the Product Backlog project -->